### PR TITLE
Create UserContextProvider and hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7970,6 +7970,21 @@
         "util.promisify": "~1.0.0"
       }
     },
+    "swr": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-0.2.3.tgz",
+      "integrity": "sha512-JhuuD5ojqgjAQpZAhoPBd8Di0Mr1+ykByVKuRJdtKaxkUX/y8kMACWKkLgLQc8pcDOKEAnbIreNjU7HfqI9nHQ==",
+      "requires": {
+        "fast-deep-equal": "2.0.1"
+      },
+      "dependencies": {
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+        }
+      }
+    },
     "table": {
       "version": "5.4.6",
       "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react": "16.13.1",
     "react-bootstrap": "^1.0.1",
     "react-dom": "16.13.1",
-    "styled-components": "^5.1.1"
+    "styled-components": "^5.1.1",
+    "swr": "^0.2.3"
   },
   "devDependencies": {
     "@types/node": "^14.0.12",

--- a/src/common/UserProvider/UserProvider.tsx
+++ b/src/common/UserProvider/UserProvider.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import {
+  User,
+  UserCurrentStatus,
+  UserProviderState,
+  GatekeeperRequestError,
+} from "./interfaces";
+import PropTypes from "prop-types";
+import useSWR from "swr";
+import { fetcher } from "../../libs";
+
+export const UserProviderContext = React.createContext({} as UserProviderState);
+
+/**
+ * Provider that provides user state to any child react element
+ */
+export const UserProvider: React.FC<React.HTMLProps<HTMLDivElement>> = ({
+  children,
+}) => {
+  // The response will be updated when ever the user puts focus back on the website (if they have tabbed out, etc).
+  const response = useSWR<User | GatekeeperRequestError>("/auth/user", fetcher);
+
+  /**
+   * Computes the "status" (UserCurrentStatus) of the user depending on the response from gatekeeper
+   */
+  const status = React.useMemo((): UserCurrentStatus => {
+    if (response.error) {
+      return UserCurrentStatus.Errored;
+    } else if (!response.data) {
+      return UserCurrentStatus.Loading;
+    } else if ((response.data as GatekeeperRequestError).statusCode === 401) {
+      return UserCurrentStatus.LoggedOut;
+    } else {
+      return UserCurrentStatus.LoggedIn;
+    }
+  }, [response.error, response.data]);
+
+  return (
+    <UserProviderContext.Provider
+      value={{
+        user:
+          status === UserCurrentStatus.LoggedIn
+            ? (response.data as User)
+            : undefined,
+        status,
+      }}
+    >
+      {children}
+    </UserProviderContext.Provider>
+  );
+};
+
+UserProvider.propTypes = {
+  children: PropTypes.element,
+};

--- a/src/common/UserProvider/hooks.ts
+++ b/src/common/UserProvider/hooks.ts
@@ -1,0 +1,11 @@
+import React from "react";
+import { UserProviderContext } from "./UserProvider";
+import { UserProviderState } from "./interfaces";
+
+/**
+ * Hook that lets you see info on the currently in user
+ * @returns {UserProviderState} the state of the user
+ */
+export const useActiveUser = (): UserProviderState => {
+  return React.useContext(UserProviderContext);
+};

--- a/src/common/UserProvider/index.tsx
+++ b/src/common/UserProvider/index.tsx
@@ -1,0 +1,3 @@
+export * from "./hooks";
+export * from "./interfaces";
+export * from "./UserProvider";

--- a/src/common/UserProvider/interfaces.ts
+++ b/src/common/UserProvider/interfaces.ts
@@ -1,0 +1,31 @@
+export interface User {
+  authId: string;
+  email: string;
+  notificationEmail: string;
+  firstName?: string;
+  lastName?: string;
+  isAdmin: boolean;
+  resumeLink?: string;
+  birthYear?: number; // for age calculation
+  locationCity?: string;
+  locationState?: string;
+  locationCountry?: string;
+  isFirstGenerationCollegeStudent?: boolean;
+}
+
+export interface GatekeeperRequestError {
+  statusCode: number;
+  message: string;
+}
+
+export enum UserCurrentStatus {
+  Loading = "Loading",
+  LoggedIn = "LoggedIn",
+  LoggedOut = "LoggedOut",
+  Errored = "Errored",
+}
+
+export interface UserProviderState {
+  user?: User;
+  status: UserCurrentStatus;
+}

--- a/src/libs/fetcher.ts
+++ b/src/libs/fetcher.ts
@@ -1,0 +1,10 @@
+export async function fetcher<JSON = unknown>(
+  input: RequestInfo,
+  init?: RequestInit
+): Promise<JSON> {
+  const res = await fetch(input, {
+    ...init,
+    headers: { accept: "application/json" },
+  });
+  return res.json();
+}

--- a/src/libs/index.ts
+++ b/src/libs/index.ts
@@ -1,0 +1,1 @@
+export * from "./fetcher";

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import "bootstrap/scss/bootstrap.scss"; // we should replace this with our own SASS file
 import { AppProps } from "next/app";
 import { ThemeProvider } from "styled-components";
+import { UserProvider } from "../common/UserProvider";
 
 // TODO: add our colors and such
 const theme = {
@@ -13,7 +14,9 @@ const theme = {
 const App = ({ Component, pageProps }: AppProps): React.ReactElement => {
   return (
     <ThemeProvider theme={theme}>
-      <Component {...pageProps} />
+      <UserProvider>
+        <Component {...pageProps} />
+      </UserProvider>
     </ThemeProvider>
   );
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { Container } from "react-bootstrap";
 import Head from "next/head";
 import styled from "styled-components";
+import { useActiveUser, UserCurrentStatus } from "../common/UserProvider";
 
 const CustomHeader = styled.h1`
   color: ${(props) => props.theme.colors.primary};
@@ -11,25 +12,38 @@ const CustomHeader = styled.h1`
 /**
  * This page appears on root
  */
-const IndexPage = (): React.ReactNode => (
-  <>
-    <Head>
-      <title>This was a triumph</title>
-    </Head>
-    <Container className="pt-5">
-      <CustomHeader>Hello Next.js 👋</CustomHeader>
-      <p>
-        <b>Folder structure:</b> pages go in <code>pages/</code>,
-        components/hooks/etc go in <code>common/</code> in which the folder has
-        an index.tsx that exports all the child components like this:{" "}
-        <code>export * from "./WhateverComponent"</code>
-      </p>
-      <p>
-        For component files don't use default export (only use default export
-        for page files)
-      </p>
-    </Container>
-  </>
-);
+const IndexPage = (): React.ReactNode => {
+  const { user, status } = useActiveUser();
+
+  return (
+    <>
+      <Head>
+        <title>This was a triumph</title>
+      </Head>
+      <Container className="pt-5">
+        <CustomHeader>Hello Next.js 👋</CustomHeader>
+        <p>
+          <b>Folder structure:</b> pages go in <code>pages/</code>,
+          components/hooks/etc go in <code>common/</code> in which the folder
+          has an index.tsx that exports all the child components like this:{" "}
+          <code>export * from "./WhateverComponent"</code>
+        </p>
+        <p>
+          For component files don't use default export (only use default export
+          for page files)
+        </p>
+        <p>User Status: {status}</p>
+        <p>Returned User:</p>
+        <pre>{JSON.stringify(user, null, 4)}</pre>
+        {status == UserCurrentStatus.LoggedOut && (
+          <p>
+            Looks like you are not logged in.{" "}
+            <a href="/auth/login?r=/events">Click here to login</a>
+          </p>
+        )}
+      </Container>
+    </>
+  );
+};
 
 export default IndexPage;


### PR DESCRIPTION
closes #6﻿
- Added a hook that lets any react component have access to checking if a user is logged in and what the current information of the logged-in user is
- used useSWR to allow it to periodically replenish data (so if they log out in another tab, it updates in this tab)
- Added the React Context to the _app root to provide state to all child components
- Added a temporary example in the index.tsx file

To test:
- Go to https://portal-git-user-status-hook.tamudatathon.vercel.app/events
- You should be able to see the current user state JSON stringified
- If you are logged out there is a link where you can log in and get redirected back (you should now see the user state there)
- You can also try logging out in a different tab or window (by going to /auth/logout) and when you switch back to the events page tab you should be logged out