### PR TITLE
added join slack section for activity

### DIFF
--- a/db/activities/data_science_101.md
+++ b/db/activities/data_science_101.md
@@ -14,6 +14,8 @@ presenterSocials:
     link: https://www.facebook.com/public/John-Doe
   - type: LinkedIn
     link: https://pl.linkedin.com/in/john-doe-3b8811140/en-us?trk=people-guest_people_search-card
+slackChannel: data-science-101
+slackChannelLink: "#data_science-101-link"
 priority: 7
 relatedActivities:
   - data_science_202

--- a/db/activities/ml_start_here.md
+++ b/db/activities/ml_start_here.md
@@ -12,6 +12,8 @@ presenterAbout: Josiah has interned at Facebook, Microsoft and the CIA. He is cu
 presenterSocials:
   - type: Josiah's Medium
     link: https://medium.com/@josiahcoad
+slackChannel: ml-start-here
+slackChannelLink: "#ml-start-here-slack-link"
 priority: 7
 relatedActivities:
   - data_science_202

--- a/db/activities/ml_start_here.md
+++ b/db/activities/ml_start_here.md
@@ -12,8 +12,6 @@ presenterAbout: Josiah has interned at Facebook, Microsoft and the CIA. He is cu
 presenterSocials:
   - type: Josiah's Medium
     link: https://medium.com/@josiahcoad
-slackChannel: ml-start-here
-slackChannelLink: "#ml-start-here-slack-link"
 priority: 7
 relatedActivities:
   - data_science_202

--- a/db/activity.md
+++ b/db/activity.md
@@ -13,6 +13,8 @@ presenterSocials:
     link: https://www.facebook.com/public/John-Doe
   - type: LinkedIn
     link: https://pl.linkedin.com/in/john-doe-3b8811140/en-us?trk=people-guest_people_search-card
+slackChannel: slack channel name for activity (ml-start-here)
+slackChannelLink: slack channel link for activity (https://tamudatathon.slack.com/some_stuff)
 priority: number_between_1_10 (7)
 relatedActivities:
   - activity_file_name (data_science_202)

--- a/src/common/ActivityInfo/ActivityInfo.tsx
+++ b/src/common/ActivityInfo/ActivityInfo.tsx
@@ -108,7 +108,11 @@ export const ActivityInfo: React.FC<InfoProps> = (props: InfoProps) => {
                   <br />
                   {channelLink}
                 </Card.Text>
-                <Button href={"#slack-link-here"} variant={"outline-primary"} block>
+                <Button
+                  href={"#slack-link-here"}
+                  variant={"outline-primary"}
+                  block
+                >
                   Join our Slack!
                 </Button>
               </Card.Body>

--- a/src/common/ActivityInfo/ActivityInfo.tsx
+++ b/src/common/ActivityInfo/ActivityInfo.tsx
@@ -20,6 +20,8 @@ export interface InfoProps {
   speakerAbout: string;
   speakerSocials: SocialInfo[];
   relatedActivities?: string[];
+  slackChannel?: string;
+  slackChannelLink?: string;
 }
 
 export const formatTime = (time: Date, endTime: Date): string => {
@@ -45,6 +47,17 @@ export const ActivityInfo: React.FC<InfoProps> = (props: InfoProps) => {
      * TODO: Add activity to list of activities user is interested in during the session.
      */
   };
+
+  const channelLink = props.slackChannel ? (
+    <>
+      <br />
+      Check out this channel for discussions on this event:
+      <br />
+      <a href={props.slackChannelLink}>{props.slackChannel}</a>
+    </>
+  ) : (
+    <></>
+  );
 
   return (
     <>
@@ -83,6 +96,21 @@ export const ActivityInfo: React.FC<InfoProps> = (props: InfoProps) => {
                     </li>
                   ))}
                 </ul>
+              </Card.Body>
+            </Card>
+            <br />
+            <Card>
+              <Card.Body>
+                <Card.Title>Join the Discussion:</Card.Title>
+                <Card.Text>
+                  Join our slack to discuss with presenters, mentors, and other
+                  TAMU Datathon 2020 attendees.
+                  <br />
+                  {channelLink}
+                </Card.Text>
+                <Button href={"#slack-link-here"} variant={"outline-primary"} block>
+                  Join our Slack!
+                </Button>
               </Card.Body>
             </Card>
             {user?.isAdmin && (

--- a/src/common/ActivityInfo/ActivityInfo.tsx
+++ b/src/common/ActivityInfo/ActivityInfo.tsx
@@ -53,7 +53,9 @@ export const ActivityInfo: React.FC<InfoProps> = (props: InfoProps) => {
       <br />
       Check out this channel for discussions on this event:
       <br />
-      <a href={props.slackChannelLink}>{props.slackChannel}</a>
+      <a href={props.slackChannelLink}>
+        <b>{props.slackChannel}</b>
+      </a>
     </>
   ) : (
     <></>
@@ -109,7 +111,9 @@ export const ActivityInfo: React.FC<InfoProps> = (props: InfoProps) => {
                   {channelLink}
                 </Card.Text>
                 <Button
-                  href={"#slack-link-here"}
+                  href={
+                    "https://join.slack.com/t/tamudatathon2020/shared_invite/zt-fnyi8tdv-Tm1ArAaznmVd9cXDaglq9Q"
+                  }
                   variant={"outline-primary"}
                   block
                 >

--- a/src/pages/activities/[page].tsx
+++ b/src/pages/activities/[page].tsx
@@ -19,6 +19,8 @@ interface PageInterface {
   presenter: string;
   presenterAbout: string;
   presenterSocials: SocialInfo[];
+  slackChannel?: string;
+  slackChannelLink?: string;
   relatedActivities: string[];
 }
 
@@ -50,6 +52,8 @@ const ActivityPage: React.FC<ActivityProps> = ({ page }: ActivityProps) => {
         speakerAbout={page.presenterAbout}
         speakerSocials={page.presenterSocials}
         relatedActivities={page.relatedActivities}
+        slackChannel={page.slackChannel}
+        slackChannelLink={page.slackChannelLink}
       ></ActivityInfo>
     </>
   );


### PR DESCRIPTION
closes #48 

added the slack call to action section. the channel link will only show if it is mentioned in the markdown file.
working example is with activity ml-start-here.
new fields for the md file are for the time being named `slackChannel` and `slackChannelLink`.