### PR TITLE
Remove prop-types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,5 +25,7 @@ module.exports = {
     sourceType: "module",
   },
   plugins: ["react", "@typescript-eslint"],
-  rules: {},
+  rules: {
+    "react/prop-types": 0,
+  },
 };

--- a/src/common/Card/Card.tsx
+++ b/src/common/Card/Card.tsx
@@ -1,11 +1,11 @@
 import React from "react";
-import { Reminder } from "./Reminder";
-import * as UI from "./style";
-import PropTypes from "prop-types";
-import { ActivityCardProps } from "./interfaces";
+import moment from "moment-timezone";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowRight } from "@fortawesome/free-solid-svg-icons";
-import moment from "moment-timezone";
+
+import { Reminder } from "./Reminder";
+import * as UI from "./style";
+import { ActivityCardProps } from "./interfaces";
 
 /**
  * Formats date to a string for the start and end time.
@@ -54,8 +54,4 @@ export const Card: React.FC<ActivityCardProps> = ({ event }) => {
       </UI.EventInfo>
     </UI.StyledCard>
   );
-};
-
-Card.propTypes = {
-  event: PropTypes.any.isRequired,
 };

--- a/src/common/Card/Reminder/Reminder.tsx
+++ b/src/common/Card/Reminder/Reminder.tsx
@@ -2,7 +2,6 @@ import React, { useEffect } from "react";
 import { useState } from "react";
 import { ReminderProps } from "../interfaces";
 import * as UI from "./style";
-import PropTypes from "prop-types";
 
 /**
  * Reminder component
@@ -34,8 +33,4 @@ export const Reminder: React.FC<ReminderProps> = ({ startTime, duration }) => {
   } else {
     return <></>;
   }
-};
-
-Reminder.propTypes = {
-  startTime: PropTypes.any.isRequired,
 };

--- a/src/common/Head/Head.tsx
+++ b/src/common/Head/Head.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/prop-types */
-
 import React from "react";
 import NextHead from "next/head";
 

--- a/src/common/Misc/NavPills.tsx
+++ b/src/common/Misc/NavPills.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import Link from "next/link";
-import PropTypes from "prop-types";
 
 import * as UI from "./style";
 import { NavItemProps, NavPillsProps } from "./interfaces";
@@ -16,11 +15,6 @@ export const NavPills: React.FC<NavPillsProps> = ({ children, activeKey }) => {
   );
 };
 
-NavPills.propTypes = {
-  children: PropTypes.any,
-  activeKey: PropTypes.string,
-};
-
 // NavItem Component
 export const NavItem: React.FC<NavItemProps> = (props) => {
   const { href: hrefEntry, as, children } = props;
@@ -31,12 +25,4 @@ export const NavItem: React.FC<NavItemProps> = (props) => {
       </Link>
     </UI._NavItem>
   );
-};
-
-// children not required b/c link can be made w/o text
-// i mean it shouldn't but welp
-NavItem.propTypes = {
-  href: PropTypes.string.isRequired,
-  children: PropTypes.any,
-  as: PropTypes.string,
 };

--- a/src/common/Set/Set.tsx
+++ b/src/common/Set/Set.tsx
@@ -3,7 +3,6 @@ import { useState, useEffect } from "react";
 import { Card } from "../Card";
 import { SetProps } from "./interfaces";
 import * as UI from "./style";
-import PropTypes from "prop-types";
 
 /**
  * Set component
@@ -66,8 +65,4 @@ export const Set: React.FC<SetProps> = ({ info }) => {
       )}
     </>
   );
-};
-
-Set.propTypes = {
-  info: PropTypes.any.isRequired,
 };

--- a/src/common/UserProvider/UserProvider.tsx
+++ b/src/common/UserProvider/UserProvider.tsx
@@ -5,7 +5,6 @@ import {
   UserProviderState,
   GatekeeperRequestError,
 } from "./interfaces";
-import PropTypes from "prop-types";
 import useSWR from "swr";
 import { fetcher } from "../../libs";
 
@@ -48,8 +47,4 @@ export const UserProvider: React.FC<React.HTMLProps<HTMLDivElement>> = ({
       {children}
     </UserProviderContext.Provider>
   );
-};
-
-UserProvider.propTypes = {
-  children: PropTypes.element,
 };

--- a/src/pages/[tabId].tsx
+++ b/src/pages/[tabId].tsx
@@ -2,7 +2,6 @@
 import React from "react";
 import { GetStaticProps, GetStaticPaths } from "next";
 import { Container } from "react-bootstrap";
-import PropTypes from "prop-types";
 
 // custom components
 import { Head } from "../common/Head";
@@ -65,12 +64,6 @@ const TabPage: React.FC<IndexPageProps> = ({ page, allPages, allSets }) => {
       </EventsBlueWrapper>
     </>
   );
-};
-
-TabPage.propTypes = {
-  page: PropTypes.any,
-  allPages: PropTypes.arrayOf(PropTypes.any),
-  allSets: PropTypes.arrayOf(PropTypes.any),
 };
 
 export default TabPage;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import TabPage from "./[tabId]";
 import { GetStaticProps } from "next";
+
+import TabPage from "./[tabId]";
 import { getAllPages, Page } from "../libs/pagesAPI";
-import PropTypes from "prop-types";
 import { ActivitySection } from "../common/Set/interfaces";
 import { getPageSets, getPageSetsContent } from "../libs/setsAPI";
 
@@ -15,11 +15,6 @@ const IndexPage: React.FC<{
   allSets?: ActivitySection[];
 }> = ({ page, allPages, allSets }) => {
   return <TabPage page={page} allPages={allPages} allSets={allSets}></TabPage>;
-};
-IndexPage.propTypes = {
-  page: PropTypes.any,
-  allPages: PropTypes.arrayOf(PropTypes.any),
-  allSets: PropTypes.arrayOf(PropTypes.any),
 };
 export default IndexPage;
 


### PR DESCRIPTION
### Since we're using interfaces from Typescript, we don't need ```prop-types```.

Weird enough, ```package-lock.json``` contains ```@types/prop-types``` but ```prop-types``` isn't in the package.json. I'll have to regenerate the lock file again just in case. 

Closes #54 