### PR TITLE
cleanup activity interface

### DIFF
--- a/db/activities/closing_ceremony.md
+++ b/db/activities/closing_ceremony.md
@@ -1,6 +1,5 @@
 ---
 name: Award Ceremony
-id: closing_ceremony
 eventId: 5f8a084933c190000312a9cb
 startTime: October 18, 2020 15:30:00-500
 endTime: October 18, 2020 16:00-500

--- a/db/activities/data_science_101.md
+++ b/db/activities/data_science_101.md
@@ -1,6 +1,5 @@
 ---
 name: Data Science 101
-id: data_science_101
 eventId: 5efe2be0c7febf000306be94
 startTime: July 25, 2021 13:00:00-500
 endTime: July 25, 2021 13:45:00-500

--- a/db/activities/deep_learning.md
+++ b/db/activities/deep_learning.md
@@ -1,6 +1,5 @@
 ---
 name: Convolutional Neural Networks & Semantic Segmentation
-id: deep_learning
 startTime: July 25, 2020 18:00:00-500
 endTime: July 25, 2020 19:00:00-500
 duration: 60

--- a/db/activities/ds_start_here.md
+++ b/db/activities/ds_start_here.md
@@ -1,6 +1,5 @@
 ---
 name: "Data Science: Start Here"
-id: ds_start_here
 startTime: July 25, 2020 17:00:00-500
 endTime: July 25, 2020 19:00:00-500
 duration: 120

--- a/db/activities/ds_visualization.md
+++ b/db/activities/ds_visualization.md
@@ -1,6 +1,5 @@
 ---
 name: "DS Introduction Part 2/2: Visualization"
-id: ds_visualization
 startTime: October 17, 2020 18:30:00-500
 endTime: October 17, 2020 19:45:00-500
 duration: 75

--- a/db/activities/ds_wrangling.md
+++ b/db/activities/ds_wrangling.md
@@ -1,6 +1,5 @@
 ---
 name: "DS Introduction Part 1/2: Wrangling"
-id: ds_wrangling
 startTime: October 17, 2020 17:00:00-500
 endTime: October 17, 2020 18:15:00-500
 duration: 75

--- a/db/activities/getting_a_job.md
+++ b/db/activities/getting_a_job.md
@@ -1,6 +1,5 @@
 ---
 name: Getting a Job in Data Science
-id: getting_a_job
 startTime: July 25, 2020 16:00:00-500
 endTime: July 25, 2020 17:00:00-500
 duration: 60

--- a/db/activities/gm_career_fair.md
+++ b/db/activities/gm_career_fair.md
@@ -1,6 +1,5 @@
 ---
 name: General Motors Career Fair
-id: gm_career_fair
 startTime: October 17, 2020 12:00:00-500
 endTime: October 17, 2020 13:00:00-500
 duration: 60

--- a/db/activities/hacking_clustering.md
+++ b/db/activities/hacking_clustering.md
@@ -1,6 +1,5 @@
 ---
 name: "Hacking Unsupervised Clustering Algorithms"
-id: hacking_clustering
 startTime: July 25, 2020 16:00:00-500
 endTime: July 25, 2020 17:00:00-500
 duration: 60

--- a/db/activities/how_to_win_td.md
+++ b/db/activities/how_to_win_td.md
@@ -1,6 +1,5 @@
 ---
 name: How to Win TAMU Datathon
-id: how_to_win_td
 startTime: October 17, 2020 13:00:00-500
 endTime: October 17, 2020 14:00:00-500
 duration: 60

--- a/db/activities/hpe_workshop.md
+++ b/db/activities/hpe_workshop.md
@@ -1,6 +1,5 @@
 ---
 name: Hewlett Packard Enterprise Workshop
-id: hpe_workshop
 eventId: 5efe2be0c7febf000306be94
 startTime: October 17, 2020 15:00:00-500
 endTime: October 17, 2020 16:00:00-500

--- a/db/activities/informational.md
+++ b/db/activities/informational.md
@@ -1,6 +1,5 @@
 ---
 name: TAMU Datathon Org Informational
-id: informational
 startTime: February 4, 2021 20:00:00-600
 endTime: February 4, 2021 21:00:00-600
 duration: 60

--- a/db/activities/intro_neural_nets.md
+++ b/db/activities/intro_neural_nets.md
@@ -1,6 +1,5 @@
 ---
 name: Intro to Neural Nets
-id: intro_neural_nets
 startTime: October 17, 2020 20:00:00-500
 endTime: October 17, 2020 21:15:00-500
 duration: 75

--- a/db/activities/intro_nlp.md
+++ b/db/activities/intro_nlp.md
@@ -1,6 +1,5 @@
 ---
 name: Intro to Natural Language Processing
-id: intro_nlp
 startTime: October 17, 2020 17:00:00-500
 endTime: October 17, 2020 18:15:00-500
 duration: 75

--- a/db/activities/intro_python.md
+++ b/db/activities/intro_python.md
@@ -1,6 +1,5 @@
 ---
 name: Intro to Python
-id: intro_python
 startTime: October 17, 2020 10:30:00-500
 endTime: October 17, 2020 12:00:00-500
 duration: 90

--- a/db/activities/mathworks_workshop.md
+++ b/db/activities/mathworks_workshop.md
@@ -1,6 +1,5 @@
 ---
 name: Mathworks Workshop
-id: mathworks_workshop
 eventId: 5efe2be0c7febf000306be94
 startTime: October 17, 2020 12:00:00-500
 endTime: October 17, 2020 13:00:00-500

--- a/db/activities/midnight_musings.md
+++ b/db/activities/midnight_musings.md
@@ -1,6 +1,5 @@
 ---
 name: Midnight Musings
-id: midnight_musings
 startTime: October 17, 2020 23:30:00-500
 endTime: October 18, 2020 0:30:00-500
 duration: 60

--- a/db/activities/ml_classification.md
+++ b/db/activities/ml_classification.md
@@ -1,6 +1,5 @@
 ---
 name: "ML Introduction Part 2/2: Applied"
-id: ml_classification
 startTime: October 17, 2020 21:30:00-500
 endTime: October 17, 2020 22:45:00-500
 duration: 75

--- a/db/activities/ml_regression.md
+++ b/db/activities/ml_regression.md
@@ -1,6 +1,5 @@
 ---
 name: "ML Introduction Part 1/2: Theory"
-id: ml_regression
 startTime: October 17, 2020 20:00:00-500
 endTime: October 17, 2020 21:15:00-500
 duration: 75

--- a/db/activities/ml_start_here.md
+++ b/db/activities/ml_start_here.md
@@ -1,6 +1,5 @@
 ---
 name: "Machine Learning: Start Here"
-id: ml_start_here
 startTime: July 25, 2020 19:00:00-500
 endTime: July 25, 2020 21:00:00-500
 duration: 120

--- a/db/activities/mlh_fun_events.md
+++ b/db/activities/mlh_fun_events.md
@@ -1,6 +1,5 @@
 ---
 name: MLH Fun Events
-id: mlh_fun_events
 startTime: October 17, 2020 15:00:00-500
 endTime: October 17, 2020 16:15:00-500
 duration: 60

--- a/db/activities/model_interpretability.md
+++ b/db/activities/model_interpretability.md
@@ -1,6 +1,5 @@
 ---
 name: "Model Interpretability"
-id: model_interpretability
 startTime: October 18, 2020 12:00:00-500
 endTime: October 18, 2020 13:15:00-500
 duration: 75

--- a/db/activities/opening_ceremony.md
+++ b/db/activities/opening_ceremony.md
@@ -3,7 +3,7 @@ name: Opening Ceremony
 id: opening_ceremony
 eventId: 5efe2be0c7febf000306be94
 startTime: October 17, 2020 9:30:00-500
-endTime: October 17, 2020 10:30-500
+endTime: October 17, 2020 10:30:00-500
 duration: 60
 mediaType: embed_url
 mediaLink: https://www.youtube.com/embed/CWBjWHudTM4

--- a/db/activities/opening_ceremony.md
+++ b/db/activities/opening_ceremony.md
@@ -1,6 +1,5 @@
 ---
 name: Opening Ceremony
-id: opening_ceremony
 eventId: 5efe2be0c7febf000306be94
 startTime: October 17, 2020 9:30:00-500
 endTime: October 17, 2020 10:30:00-500

--- a/db/activities/reccomendation_engine.md
+++ b/db/activities/reccomendation_engine.md
@@ -1,6 +1,5 @@
 ---
 name: "Recommendation Engines"
-id: reccomendation_engine
 startTime: October 17, 2020 18:30:00-500
 endTime: October 17, 2020 19:45:00-500
 eventId: 5f8a0bb033c190000312a9d3

--- a/db/activities/reinforcement_learning.md
+++ b/db/activities/reinforcement_learning.md
@@ -1,6 +1,5 @@
 ---
 name: "Reinforcement Learning"
-id: reinforcement_learning
 startTime: October 17, 2020 21:30:00-500
 endTime: October 17, 2020 22:45:00-500
 duration: 75

--- a/db/activities/start_here_sh.md
+++ b/db/activities/start_here_sh.md
@@ -1,6 +1,5 @@
 ---
 name: "Data Science: Start Here"
-id: start_here_sh
 startTime: June 20, 2020 10:30:00
 endTime: June 20, 2020 11:30:00
 eventId: 5f1bbd0819f52100035dd9fc

--- a/db/activities/stats_for_ds.md
+++ b/db/activities/stats_for_ds.md
@@ -1,6 +1,5 @@
 ---
 name: "Stats for Data Science"
-id: stats_for_ds
 startTime: October 17, 2020 16:00:00-500
 endTime: October 17, 2020 17:00:00-500
 duration: 75

--- a/db/activities/story_telling.md
+++ b/db/activities/story_telling.md
@@ -1,6 +1,5 @@
 ---
 name: Storytelling with Data
-id: story_telling
 startTime: October 18, 2020 14:00:00-500
 endTime: October 18, 2020 15:00:00-500
 duration: 75

--- a/db/activities/tableau_workshop.md
+++ b/db/activities/tableau_workshop.md
@@ -1,6 +1,5 @@
 ---
 name: Tableau Workshop
-id: tableau_workshop
 eventId: 5f8a0d7033c190000312a9d7
 startTime: Oct 17, 2020 16:00:00-500
 endTime: Oct 17, 2020 17:00:00-500

--- a/db/activities/tamids_career_fair.md
+++ b/db/activities/tamids_career_fair.md
@@ -1,6 +1,5 @@
 ---
 name: Texas A&M Institute of Data Science Q&A
-id: tamids_career_fair
 eventId: 5f8a0da233c190000312a9d8
 startTime: Oct 17, 2020 10:30:00-500
 endTime: Oct 17, 2020 11:00:00-500

--- a/db/activities/tamids_workshop.md
+++ b/db/activities/tamids_workshop.md
@@ -1,6 +1,5 @@
 ---
 name: Texas A&M Institute of Data Science Workshop
-id: tamids_workshop
 eventId: 5f8a0de433c190000312a9d9
 startTime: Oct 17, 2020 11:00:00-500
 endTime: Oct 17, 2020 12:00:00-500

--- a/db/activities/team_building.md
+++ b/db/activities/team_building.md
@@ -1,6 +1,5 @@
 ---
 name: Team Building
-id: team_building
 eventId: 5f8b0d28f825fcca1859d3a2
 startTime: October 17, 2020 10:30:00-500
 endTime: October 17, 2020 12:00:00-500

--- a/db/activities/tti_career_fair.md
+++ b/db/activities/tti_career_fair.md
@@ -1,6 +1,5 @@
 ---
 name: Texas Transportation Institute Career Fair
-id: tti_career_fair
 startTime: October 17, 2020 15:00:00-500
 endTime: October 17, 2020 16:00:00-500
 duration: 60

--- a/db/activities/tti_workshop.md
+++ b/db/activities/tti_workshop.md
@@ -1,6 +1,5 @@
 ---
 name: Texas Transporation Institute Workshop
-id: tti_workshop
 eventId: 5efe2be0c7febf000306be94
 startTime: Oct 17, 2020 14:00:00-500
 endTime: Oct 17, 2020 15:00:00-500

--- a/db/activities/walmart_workshop.md
+++ b/db/activities/walmart_workshop.md
@@ -1,6 +1,5 @@
 ---
 name: Walmart Workshop
-id: walmart_workshop
 eventId: 5efe2be0c7febf000306be94
 startTime: October 17, 2020 13:00:00-500
 endTime: October 17, 2020 14:00:00-500

--- a/db/activity.md
+++ b/db/activity.md
@@ -1,6 +1,5 @@
 ---
 name: string (Data Science 101)
-id: file_name_without_extension (data_science_101)
 eventId: event_id_in_gatekeeper (mongo_db_id)
 startTime: Month Date, Year hh:mm:ss (June 20, 2020 10:30:00)
 endTime: Month Date, Year hh:mm:ss (June 20, 2020 11:30:00)

--- a/db/activity.md
+++ b/db/activity.md
@@ -3,7 +3,8 @@ name: string (Data Science 101)
 id: file_name_without_extension (data_science_101)
 eventId: event_id_in_gatekeeper (mongo_db_id)
 startTime: Month Date, Year hh:mm:ss (June 20, 2020 10:30:00)
-endTime: Month Date, Year hh:mm:ss (June 20, 2020 10:30:00)
+endTime: Month Date, Year hh:mm:ss (June 20, 2020 11:30:00)
+duration: number of minutes (60)
 mediaType: "meeting_url" or "embed_url" (one or the other)
 mediaLink: url_string (https://tamu.zoom.us/j/28347923874)
 thumbnail: string (https://tamudatathon.com/portal/db/img/ds101.png)
@@ -21,6 +22,7 @@ relatedActivities:
   - activity_file_name (data_science_202)
   - activity_file_name (data_science_303)
   - activity_file_name (data_science_404)
+tabs: comma separated list of strings (python, c++, javascript)
 ---
 
 The activity body goes here

--- a/db/page.yaml
+++ b/db/page.yaml
@@ -1,5 +1,4 @@
 name: string (Day 1)
-id: file_name_without_extension (day_1)
 orderedBy: order_type (alphabetical / priority / start_time / none)
 sets:
   - set_file_name (starter_set)

--- a/db/pages/expo.yaml
+++ b/db/pages/expo.yaml
@@ -1,5 +1,4 @@
 name: Company Events
-id: expo
 orderedBy: none
 priority: 3
 sets:

--- a/db/pages/featured.yaml
+++ b/db/pages/featured.yaml
@@ -1,5 +1,4 @@
 name: Featured
-id: featured
 orderedBy: none
 priority: 0
 sets:

--- a/db/set.yaml
+++ b/db/set.yaml
@@ -1,5 +1,4 @@
 name: string (Get started with Data Science)
-id: file_name_without_extension (get_started_set)
 description: string (New to Data Science? Attend these live classes to improve your skill!)
 showMoreState: boolean (true/false)
 orderedBy: order_type (start_time / alphabetical / attendance / none)

--- a/db/sets/beginner_bootcamp_set.yaml
+++ b/db/sets/beginner_bootcamp_set.yaml
@@ -1,5 +1,4 @@
 name: Perfect for Beginners
-id: beginner_bootcamp_set
 description: New to Data Science or Machine Learning? These events should help you understand what makes it great!
 showMoreState: true
 orderBy: start_time

--- a/db/sets/beginner_classes_set.yaml
+++ b/db/sets/beginner_classes_set.yaml
@@ -1,5 +1,4 @@
 name: Beginner Classes
-id: beginner_classes_set
 description: Get started with classes that require no prior knowledge!
 showMoreState: true
 orderedBy: start_time

--- a/db/sets/career_fair_set.yaml
+++ b/db/sets/career_fair_set.yaml
@@ -1,5 +1,4 @@
 name: Career Fair
-id: career_fair_set
 description: Showcase yourself to company recruiters and industry professionals
 showMoreState: true
 orderBy: start_time

--- a/db/sets/company_workshops_set.yaml
+++ b/db/sets/company_workshops_set.yaml
@@ -1,5 +1,4 @@
 name: Company Workshops
-id: company_workshops_set
 description: Learn from industry and see how these companies use DS/ML technologies in there day to day.
 showMoreState: true
 orderedBy: start_time

--- a/db/sets/core_curriculum_set.yaml
+++ b/db/sets/core_curriculum_set.yaml
@@ -1,5 +1,4 @@
 name: TAMU Datathon Core Curriculum
-id: core_curriculum_set
 description: Learn the fundamentals of data science to get the ball rolling!
 showMoreState: true
 orderedBy: start_time

--- a/db/sets/day1_set.yaml
+++ b/db/sets/day1_set.yaml
@@ -1,6 +1,5 @@
 # for use on the day 1 page
 name: Day 1 Events
-id: day1_set
 description: Events on Saturday Oct. 17th 2020
 showMoreState: true
 orderBy: start_time

--- a/db/sets/day2_set.yaml
+++ b/db/sets/day2_set.yaml
@@ -1,6 +1,5 @@
 # for use on the day 1 page
 name: Day 2 Events
-id: day1_set
 description: Events on Sunday Oct. 18th 2020
 showMoreState: true
 orderBy: start_time

--- a/db/sets/dive_deeper_set.yaml
+++ b/db/sets/dive_deeper_set.yaml
@@ -1,5 +1,4 @@
 name: Dive Deeper
-id: dive_deeper_set
 description: Tackle advanced topics in DS/ML to get a deeper understanding!
 showMoreState: true
 orderBy: start_time

--- a/db/sets/getting_started_set.yaml
+++ b/db/sets/getting_started_set.yaml
@@ -1,5 +1,4 @@
 name: Getting Started
-id: getting_started_set
 description: Learn the fundamentals of data science to get the ball rolling!
 showMoreState: false
 orderBy: start_time

--- a/db/sets/happening_now_set.yaml
+++ b/db/sets/happening_now_set.yaml
@@ -1,5 +1,4 @@
 name: Happening Now
-id: happening_now_set
 description: These events are starting soon or are ongoing. Join before it's too late!
 showMoreState: true
 orderBy: start_time

--- a/db/sets/informational_set.yaml
+++ b/db/sets/informational_set.yaml
@@ -1,5 +1,4 @@
 name: Informational Events
-id: informational_set
 description: Join these to get key information about the event.
 showMoreState: false
 orderBy: start_time

--- a/db/sets/intermediate_bootcamp_set.yaml
+++ b/db/sets/intermediate_bootcamp_set.yaml
@@ -1,5 +1,4 @@
 name: Perfect for Intermediates
-id: intermediate_bootcamp_set
 description: Experienced with Data Science or Machine Learning? These events will dive into exciting applications of your skills.
 showMoreState: true
 orderBy: start_time

--- a/db/sets/social_events_set.yaml
+++ b/db/sets/social_events_set.yaml
@@ -1,5 +1,4 @@
 name: Fun Events
-id: social_events_set
 description: Take a break and have some fun
 showMoreState: false
 orderBy: start_time

--- a/src/common/ActivityInfo/ActivityInfo.tsx
+++ b/src/common/ActivityInfo/ActivityInfo.tsx
@@ -23,7 +23,7 @@ export interface SocialInfo {
 export interface ActivityInfoProps {
   name: string;
   id: string;
-  eventId: string,
+  eventId: string;
   startTime: string;
   endTime: string;
   duration: number;
@@ -67,7 +67,9 @@ export const formatGoogleTime = (startTime: Date, endTime: Date): string => {
   );
 };
 
-export const ActivityInfo: React.FC<ActivityInfoProps> = (props: ActivityInfoProps) => {
+export const ActivityInfo: React.FC<ActivityInfoProps> = (
+  props: ActivityInfoProps
+) => {
   // const [interested, setInterested] = useState(false);
   const { user } = useActiveUser();
   const curTime = new Date();
@@ -186,9 +188,7 @@ export const ActivityInfo: React.FC<ActivityInfoProps> = (props: ActivityInfoPro
             <Card>
               <Card.Body>
                 <Card.Title>When:</Card.Title>
-                <Card.Text>
-                  {formatTime(startTime, endTime)}
-                </Card.Text>
+                <Card.Text>{formatTime(startTime, endTime)}</Card.Text>
                 <Card.Title>Presented By:</Card.Title>
                 <Card.Text>{props.presenter}</Card.Text>
                 <Card.Title>About the Speaker(s):</Card.Title>
@@ -196,11 +196,12 @@ export const ActivityInfo: React.FC<ActivityInfoProps> = (props: ActivityInfoPro
                   {props.presenterAbout}
                 </Card.Text>
                 <ul>
-                  {props.presenterSocials && props.presenterSocials.map((social: SocialInfo) => (
-                    <li key={social.type + "_" + social.link}>
-                      <Card.Link href={social.link}>{social.type}</Card.Link>
-                    </li>
-                  ))}
+                  {props.presenterSocials &&
+                    props.presenterSocials.map((social: SocialInfo) => (
+                      <li key={social.type + "_" + social.link}>
+                        <Card.Link href={social.link}>{social.type}</Card.Link>
+                      </li>
+                    ))}
                 </ul>
               </Card.Body>
             </Card>

--- a/src/common/ActivityInfo/ActivityInfo.tsx
+++ b/src/common/ActivityInfo/ActivityInfo.tsx
@@ -20,18 +20,25 @@ export interface SocialInfo {
   link: string;
 }
 
-export interface InfoProps {
-  title: string;
+export interface ActivityInfoProps {
+  name: string;
   id: string;
-  description: string;
-  startTime: Date;
-  endTime: Date;
-  speakerName: string;
-  speakerAbout: string;
-  speakerSocials: SocialInfo[];
-  relatedActivities?: string[];
+  eventId: string,
+  startTime: string;
+  endTime: string;
+  duration: number;
+  mediaType: "embed_url" | "meeting_url" | "embed_url_require_auth";
+  mediaLink: string;
+  thumbnail: string;
+  presenter: string;
+  presenterAbout: string;
+  presenterSocials: SocialInfo[];
   slackChannel?: string;
   slackChannelLink?: string;
+  priority: number;
+  relatedActivities?: string[];
+  tabs: string;
+  content: string;
 }
 
 /**
@@ -60,11 +67,11 @@ export const formatGoogleTime = (startTime: Date, endTime: Date): string => {
   );
 };
 
-export const ActivityInfo: React.FC<InfoProps> = (props: InfoProps) => {
+export const ActivityInfo: React.FC<ActivityInfoProps> = (props: ActivityInfoProps) => {
   // const [interested, setInterested] = useState(false);
   const { user } = useActiveUser();
   const curTime = new Date();
-  const minsToEvent = props.startTime.getTime() - curTime.getTime();
+  const minsToEvent = new Date(props.startTime).getTime() - curTime.getTime();
 
   // const handleClick = () => {
   //   setInterested(!interested);
@@ -88,7 +95,7 @@ export const ActivityInfo: React.FC<InfoProps> = (props: InfoProps) => {
     const event = {
       start: startTimeArr as ics.DateArray,
       end: endTimeArr as ics.DateArray,
-      title: props.title,
+      title: props.name,
       description: `Attend Here: tamudatathon.com/events/activities/${props.id}`,
       url: `https://tamudatathon.com/events/activities/${props.id}`,
     };
@@ -119,8 +126,8 @@ export const ActivityInfo: React.FC<InfoProps> = (props: InfoProps) => {
               href={
                 `https://www.google.com/calendar/render?` +
                 `action=TEMPLATE&` +
-                `text=${props.title}&` +
-                `dates=${formatGoogleTime(props.startTime, props.endTime)}&` +
+                `text=${props.name}&` +
+                `dates=${formatGoogleTime(new Date(props.startTime), new Date(props.endTime))}&` +
                 `details=Attend Here: tamudatathon.com/events/activities/${props.id}&` +
                 `ctz=America/Chicago`
               }
@@ -154,13 +161,13 @@ export const ActivityInfo: React.FC<InfoProps> = (props: InfoProps) => {
   return (
     <>
       <Container className="mt-4 mb-5">
-        <h2 className="pb-3">{props.title}</h2>
+        <h2 className="pb-3">{props.name}</h2>
         <Row>
           <Col className="min-vh-100 mb-5">
             <ReactMarkdown
               linkTarget="_blank"
               escapeHtml={false}
-              source={props.description}
+              source={props.content}
             />
           </Col>
           <Col lg={4} md={12}>
@@ -178,16 +185,16 @@ export const ActivityInfo: React.FC<InfoProps> = (props: InfoProps) => {
               <Card.Body>
                 <Card.Title>When:</Card.Title>
                 <Card.Text>
-                  {formatTime(props.startTime, props.endTime)}
+                  {formatTime(new Date(props.startTime), new Date(props.endTime))}
                 </Card.Text>
                 <Card.Title>Presented By:</Card.Title>
-                <Card.Text>{props.speakerName}</Card.Text>
+                <Card.Text>{props.presenter}</Card.Text>
                 <Card.Title>About the Speaker(s):</Card.Title>
                 <Card.Text style={{ marginTop: "0.75rem" }}>
-                  {props.speakerAbout}
+                  {props.presenterAbout}
                 </Card.Text>
                 <ul>
-                  {props.speakerSocials.map((social: SocialInfo) => (
+                  {props.presenterSocials && props.presenterSocials.map((social: SocialInfo) => (
                     <li key={social.type + "_" + social.link}>
                       <Card.Link href={social.link}>{social.type}</Card.Link>
                     </li>

--- a/src/common/ActivityInfo/ActivityInfo.tsx
+++ b/src/common/ActivityInfo/ActivityInfo.tsx
@@ -71,7 +71,9 @@ export const ActivityInfo: React.FC<ActivityInfoProps> = (props: ActivityInfoPro
   // const [interested, setInterested] = useState(false);
   const { user } = useActiveUser();
   const curTime = new Date();
-  const minsToEvent = new Date(props.startTime).getTime() - curTime.getTime();
+  const startTime = new Date(props.startTime);
+  const endTime = new Date(props.endTime);
+  const minsToEvent = startTime.getTime() - curTime.getTime();
 
   // const handleClick = () => {
   //   setInterested(!interested);
@@ -127,7 +129,7 @@ export const ActivityInfo: React.FC<ActivityInfoProps> = (props: ActivityInfoPro
                 `https://www.google.com/calendar/render?` +
                 `action=TEMPLATE&` +
                 `text=${props.name}&` +
-                `dates=${formatGoogleTime(new Date(props.startTime), new Date(props.endTime))}&` +
+                `dates=${formatGoogleTime(startTime, endTime)}&` +
                 `details=Attend Here: tamudatathon.com/events/activities/${props.id}&` +
                 `ctz=America/Chicago`
               }
@@ -185,7 +187,7 @@ export const ActivityInfo: React.FC<ActivityInfoProps> = (props: ActivityInfoPro
               <Card.Body>
                 <Card.Title>When:</Card.Title>
                 <Card.Text>
-                  {formatTime(new Date(props.startTime), new Date(props.endTime))}
+                  {formatTime(startTime, endTime)}
                 </Card.Text>
                 <Card.Title>Presented By:</Card.Title>
                 <Card.Text>{props.presenter}</Card.Text>

--- a/src/common/Card/Card.tsx
+++ b/src/common/Card/Card.tsx
@@ -37,18 +37,15 @@ export const Card: React.FC<ActivityCardProps> = ({ event }) => {
     <UI.StyledCard>
       <UI.EventImgContainer>
         <UI.EventImg src={event.thumbnail} alt="" />
-        <Reminder
-          startTime={startTime}
-          duration={event.duration}
-        />
+        <Reminder startTime={startTime} duration={event.duration} />
       </UI.EventImgContainer>
       <UI.EventInfo>
         <h5>{event.name}</h5>
-        <UI.EventTime>
-          {formatTime(startTime, event.duration)}
-        </UI.EventTime>
+        <UI.EventTime>{formatTime(startTime, event.duration)}</UI.EventTime>
         <UI.EventInfoLinkContainer>
-          <UI.EventInfoLink href={event.mediaLink ? `/events/activities/${event.id}` : "#"}>
+          <UI.EventInfoLink
+            href={event.mediaLink ? `/events/activities/${event.id}` : "#"}
+          >
             Learn more <FontAwesomeIcon icon={faArrowRight} />
           </UI.EventInfoLink>
         </UI.EventInfoLinkContainer>

--- a/src/common/Card/Card.tsx
+++ b/src/common/Card/Card.tsx
@@ -32,19 +32,20 @@ export const formatTime = (time: Date, duration: number): string => {
  * Card component
  */
 export const Card: React.FC<ActivityCardProps> = ({ event }) => {
+  const startTime = new Date(event.startTime);
   return (
     <UI.StyledCard>
       <UI.EventImgContainer>
         <UI.EventImg src={event.thumbnail} alt="" />
         <Reminder
-          startTime={new Date(event.startTime)}
+          startTime={startTime}
           duration={event.duration}
         />
       </UI.EventImgContainer>
       <UI.EventInfo>
         <h5>{event.name}</h5>
         <UI.EventTime>
-          {formatTime(new Date(event.startTime), event.duration)}
+          {formatTime(startTime, event.duration)}
         </UI.EventTime>
         <UI.EventInfoLinkContainer>
           <UI.EventInfoLink href={event.mediaLink ? `/events/activities/${event.id}` : "#"}>

--- a/src/common/Card/Card.tsx
+++ b/src/common/Card/Card.tsx
@@ -35,19 +35,19 @@ export const Card: React.FC<ActivityCardProps> = ({ event }) => {
   return (
     <UI.StyledCard>
       <UI.EventImgContainer>
-        <UI.EventImg src={event.imgUrl} alt="" />
+        <UI.EventImg src={event.thumbnail} alt="" />
         <Reminder
           startTime={new Date(event.startTime)}
           duration={event.duration}
         />
       </UI.EventImgContainer>
       <UI.EventInfo>
-        <h5>{event.title}</h5>
+        <h5>{event.name}</h5>
         <UI.EventTime>
           {formatTime(new Date(event.startTime), event.duration)}
         </UI.EventTime>
         <UI.EventInfoLinkContainer>
-          <UI.EventInfoLink href={event.infoUrl || "#"}>
+          <UI.EventInfoLink href={event.mediaLink ? `/events/activities/${event.id}` : "#"}>
             Learn more <FontAwesomeIcon icon={faArrowRight} />
           </UI.EventInfoLink>
         </UI.EventInfoLinkContainer>

--- a/src/common/Card/interfaces.tsx
+++ b/src/common/Card/interfaces.tsx
@@ -1,14 +1,7 @@
-export interface Activity {
-  imgUrl: string;
-  title: string;
-  startTime: string;
-  endTime?: string;
-  duration: number;
-  infoUrl: string;
-}
+import { ActivityInfoProps } from "../ActivityInfo";
 
 export interface ActivityCardProps {
-  event: Activity;
+  event: ActivityInfoProps;
 }
 
 export interface ReminderProps {

--- a/src/common/Media/Media.tsx
+++ b/src/common/Media/Media.tsx
@@ -10,7 +10,7 @@ export enum CallStatus {
 }
 
 export interface MediaProps {
-  type: "embed_url" | "meeting_url";
+  type: "embed_url" | "meeting_url" | "embed_url_require_auth";
   link: string;
   callStatus?: CallStatus;
 }

--- a/src/common/Set/Set.tsx
+++ b/src/common/Set/Set.tsx
@@ -15,23 +15,23 @@ const TIME_BEFORE_SHOW_BADGE_MS = 15 * 60000;
 export const Set: React.FC<SetProps> = ({ info }) => {
   const currentTime = useCurrentTime();
   const [eventList, setEventList] = useState(
-    info.eventList.slice(
+    info.activityListPopulated.slice(
       0,
-      !info.defaultShowMoreState ? 4 : info.eventList.length
+      !info.showMoreState ? 4 : info.activityListPopulated.length
     )
   );
-  const [showMore, setShowMore] = useState(info.defaultShowMoreState);
+  const [showMore, setShowMore] = useState(info.showMoreState);
   const [btnText, setBtnText] = useState(
-    !info.defaultShowMoreState ? "Show More" : "Show Less"
+    !info.showMoreState ? "Show More" : "Show Less"
   );
 
   /* Updates the set component if when the show more status has been changed */
   useEffect(() => {
     if (showMore) {
-      setEventList(info.eventList);
+      setEventList(info.activityListPopulated);
       setBtnText("Show Less");
     } else {
-      setEventList(info.eventList.slice(0, 4));
+      setEventList(info.activityListPopulated.slice(0, 4));
       setBtnText("Show More");
     }
   }, [showMore]);
@@ -46,11 +46,11 @@ export const Set: React.FC<SetProps> = ({ info }) => {
   /** Applies all filters and sorts if specified */
   const transformedEventList = React.useMemo(() => {
     let currArr = eventList;
-    if (info.orderedBy === "alphabetical") {
+    if (info.orderBy === "alphabetical") {
       currArr = currArr.sort((a, b) =>
         a.event.name.localeCompare(b.event.name)
       );
-    } else if (info.orderedBy === "start_time") {
+    } else if (info.orderBy === "start_time") {
       currArr = currArr.sort(
         (a, b) =>
           new Date(a.event.startTime).getTime() -
@@ -58,7 +58,7 @@ export const Set: React.FC<SetProps> = ({ info }) => {
       );
     }
 
-    if (info.filteredBy === "happening_now") {
+    if (info.filterBy === "happening_now") {
       // this is dumb af, i know
       currArr = currArr.filter(
         (item) =>
@@ -75,7 +75,7 @@ export const Set: React.FC<SetProps> = ({ info }) => {
     }
 
     return currArr;
-  }, [eventList, info.orderedBy, info.filteredBy, currentTime]);
+  }, [eventList, info.orderBy, info.filterBy, currentTime]);
 
   /* Toggles whether the set is displayed fully or partially */
   const toggleEventsDisplay = () => {
@@ -89,8 +89,8 @@ export const Set: React.FC<SetProps> = ({ info }) => {
   return (
     <>
       <UI.SectionInfo>
-        <h4>{info.sectionTitle}</h4>
-        <p>{info.sectionDescription}</p>
+        <h4>{info.name}</h4>
+        <p>{info.description}</p>
       </UI.SectionInfo>
       <UI.CardsContainer>
         {transformedEventList.map((card) => (
@@ -100,7 +100,7 @@ export const Set: React.FC<SetProps> = ({ info }) => {
           />
         ))}
       </UI.CardsContainer>
-      {info.eventList.length > 4 ? (
+      {info.activityListPopulated.length > 4 ? (
         <UI.ShowBtnContainer>
           <UI.Hr />
           <UI.ShowBtn onClick={toggleEventsDisplay}>{btnText}</UI.ShowBtn>

--- a/src/common/Set/Set.tsx
+++ b/src/common/Set/Set.tsx
@@ -48,7 +48,7 @@ export const Set: React.FC<SetProps> = ({ info }) => {
     let currArr = eventList;
     if (info.orderedBy === "alphabetical") {
       currArr = currArr.sort((a, b) =>
-        a.event.title.localeCompare(b.event.title)
+        a.event.name.localeCompare(b.event.name)
       );
     } else if (info.orderedBy === "start_time") {
       currArr = currArr.sort(
@@ -95,7 +95,7 @@ export const Set: React.FC<SetProps> = ({ info }) => {
       <UI.CardsContainer>
         {transformedEventList.map((card) => (
           <Card
-            key={card.event.title + card.event.startTime + card.event.duration}
+            key={card.event.name + card.event.startTime + card.event.duration}
             event={card.event}
           />
         ))}

--- a/src/common/Set/interfaces.ts
+++ b/src/common/Set/interfaces.ts
@@ -1,12 +1,15 @@
 import { ActivityCardProps } from "../Card";
 
 export interface ActivitySection {
-  eventList: Array<ActivityCardProps>;
-  sectionTitle: string;
-  sectionDescription: string;
-  orderedBy?: string;
-  filteredBy?: string;
-  defaultShowMoreState?: boolean;
+  name: string;
+  id: string;
+  description: string;
+  showMoreState: boolean;
+  orderBy: "alphabetical" | "priority" | "start_time" | "none" | "" | undefined;
+  filterBy: "happening_now" | undefined;
+  priority: number;
+  activityList: Array<string>;
+  activityListPopulated: Array<ActivityCardProps>;
 }
 
 export interface SetProps {

--- a/src/libs/activitiesAPI.ts
+++ b/src/libs/activitiesAPI.ts
@@ -23,7 +23,7 @@ export async function getActivityByName(page: string): Promise<ActivityInfoProps
   const fileContents = await fs.promises.readFile(fullPath, "utf8");
   const { data, content } = matter(fileContents);
 
-  return { ...data, content } as ActivityInfoProps;
+  return { ...data, content, id: realPage } as ActivityInfoProps;
 }
 
 /**

--- a/src/libs/activitiesAPI.ts
+++ b/src/libs/activitiesAPI.ts
@@ -17,7 +17,9 @@ export async function getActivityNames(): Promise<string[]> {
  * @param {string} page ID of the activity (filename without .md)
  * @returns {Promise<Activity>}
  */
-export async function getActivityByName(page: string): Promise<ActivityInfoProps> {
+export async function getActivityByName(
+  page: string
+): Promise<ActivityInfoProps> {
   const realPage = page.replace(/\.md$/, "");
   const fullPath = join(activityDirectory, `${realPage}.md`);
   const fileContents = await fs.promises.readFile(fullPath, "utf8");

--- a/src/libs/activitiesAPI.ts
+++ b/src/libs/activitiesAPI.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import { join } from "path";
 import matter from "gray-matter";
+import { ActivityInfoProps } from "../common/ActivityInfo";
 
 const activityDirectory = join(process.cwd(), "db/activities");
 
@@ -11,40 +12,24 @@ export async function getActivityNames(): Promise<string[]> {
   return fs.promises.readdir(activityDirectory);
 }
 
-export interface Activity {
-  name: string;
-  id: string;
-  eventId: string;
-  startTime: string;
-  endTime: string;
-  duration: number;
-  mediaType: "meeting_url" | "embed_url" | "embed_url_require_auth";
-  mediaLink: string;
-  thumbnail: string;
-  presenter: string;
-  priority: number;
-  relatedActivities: string[];
-  content: string;
-}
-
 /**
  * Returns contents of an activity file in activityDirectory as JSON
  * @param {string} page ID of the activity (filename without .md)
  * @returns {Promise<Activity>}
  */
-export async function getActivityByName(page: string): Promise<Activity> {
+export async function getActivityByName(page: string): Promise<ActivityInfoProps> {
   const realPage = page.replace(/\.md$/, "");
   const fullPath = join(activityDirectory, `${realPage}.md`);
   const fileContents = await fs.promises.readFile(fullPath, "utf8");
   const { data, content } = matter(fileContents);
 
-  return { ...data, content } as Activity;
+  return { ...data, content } as ActivityInfoProps;
 }
 
 /**
  * @returns {Promise<Activity[]>} list of contents of the activitiy files in the activityDirectory path
  */
-export async function getAllActivities(): Promise<Activity[]> {
+export async function getAllActivities(): Promise<ActivityInfoProps[]> {
   const activityNames = await getActivityNames();
   const pages = activityNames.map((page) => getActivityByName(page));
   return Promise.all(pages);

--- a/src/libs/pagesAPI.ts
+++ b/src/libs/pagesAPI.ts
@@ -30,7 +30,7 @@ export async function getPageByName(pageName: string): Promise<Page> {
   const fileContents = await fs.promises.readFile(fullPath, "utf8");
   const data = yaml.safeLoad(fileContents);
 
-  return data as Page;
+  return {...(data as object), id: realPage} as Page;
 }
 
 /**

--- a/src/libs/pagesAPI.ts
+++ b/src/libs/pagesAPI.ts
@@ -30,7 +30,7 @@ export async function getPageByName(pageName: string): Promise<Page> {
   const fileContents = await fs.promises.readFile(fullPath, "utf8");
   const data = yaml.safeLoad(fileContents);
 
-  return {...(data as object), id: realPage} as Page;
+  return { ...(data as Page), id: realPage } as Page;
 }
 
 /**

--- a/src/libs/setsAPI.ts
+++ b/src/libs/setsAPI.ts
@@ -3,7 +3,7 @@ import { join } from "path";
 import yaml from "js-yaml";
 import { getPageByName } from "./pagesAPI";
 import { ActivitySection } from "../common/Set/interfaces";
-import { Activity, ActivityCardProps } from "../common/Card/interfaces";
+import { ActivityCardProps } from "../common/Card/interfaces";
 import { getActivityByName } from "../libs/activitiesAPI";
 
 const setDirectory = join(process.cwd(), "db/sets");
@@ -73,15 +73,7 @@ export async function getPageSetsContent(
       const activities: Array<ActivityCardProps> = await Promise.all(
         set.activityList.map(async (activity) => {
           const activityFileContent = await getActivityByName(activity);
-          const activityContent: Activity = {
-            imgUrl: activityFileContent.thumbnail,
-            title: activityFileContent.name,
-            startTime: activityFileContent.startTime,
-            endTime: activityFileContent.endTime,
-            duration: activityFileContent.duration,
-            infoUrl: `/events/activities/${activityFileContent.id}`,
-          };
-          return { event: activityContent };
+          return { event: activityFileContent };
         })
       );
       const setObject: ActivitySection = {

--- a/src/libs/setsAPI.ts
+++ b/src/libs/setsAPI.ts
@@ -15,35 +15,24 @@ export async function getSetNames(): Promise<string[]> {
   return fs.promises.readdir(setDirectory);
 }
 
-export interface Set {
-  name: string;
-  id: string;
-  description: string;
-  showMoreState: boolean;
-  orderBy: "alphabetical" | "priority" | "start_time" | "none" | "" | undefined;
-  filterBy: "happening_now" | undefined;
-  priority: number;
-  activityList: string[];
-}
-
 /**
  * Returns contents of a set file in setDirectory as JSON
  * @param {string} set ID of the set (filename without .yaml)
  * @returns {Promise<Set>}
  */
-export async function getSetByName(setName: string): Promise<Set> {
+export async function getSetByName(setName: string): Promise<ActivitySection> {
   const realSet = setName.replace(/\.yaml$/, "");
   const fullPath = join(setDirectory, `${realSet}.yaml`);
   const fileContents = await fs.promises.readFile(fullPath, "utf8");
   const data = yaml.safeLoad(fileContents);
 
-  return data as Set;
+  return {...(data as object), id: realSet} as ActivitySection;
 }
 
 /**
  * @returns {Promise<Set[]>} list of contents of the set files in setDirectory
  */
-export async function getAllSets(): Promise<Set[]> {
+export async function getAllSets(): Promise<ActivitySection[]> {
   const setNames = await getSetNames();
   const sets = setNames.map((set) => getSetByName(set));
   return Promise.all(sets);
@@ -53,7 +42,7 @@ export async function getAllSets(): Promise<Set[]> {
  * @param {string} pageName Name of the page you want the sets for.
  * @returns {Promise<Set[]>} list of contents of the sets listed in the page yaml
  */
-export async function getPageSets(pageName: string): Promise<Set[]> {
+export async function getPageSets(pageName: string): Promise<ActivitySection[]> {
   const pageData = await getPageByName(pageName);
   const sets = pageData.sets.map((set) => getSetByName(set));
 
@@ -66,7 +55,7 @@ export async function getPageSets(pageName: string): Promise<Set[]> {
  * @returns Promise<ActivitySection[]> Promise of a list of sets.
  */
 export async function getPageSetsContent(
-  tabSets: Set[]
+  tabSets: ActivitySection[]
 ): Promise<ActivitySection[]> {
   const allSets = await Promise.all(
     tabSets.map(async (set) => {
@@ -77,12 +66,8 @@ export async function getPageSetsContent(
         })
       );
       const setObject: ActivitySection = {
-        eventList: activities,
-        sectionTitle: set.name,
-        sectionDescription: set.description,
-        orderedBy: set.orderBy || "",
-        filteredBy: set.filterBy || "",
-        defaultShowMoreState: set.showMoreState,
+        ...set,
+        activityListPopulated: activities,
       };
       return setObject;
     })

--- a/src/libs/setsAPI.ts
+++ b/src/libs/setsAPI.ts
@@ -26,7 +26,7 @@ export async function getSetByName(setName: string): Promise<ActivitySection> {
   const fileContents = await fs.promises.readFile(fullPath, "utf8");
   const data = yaml.safeLoad(fileContents);
 
-  return {...(data as object), id: realSet} as ActivitySection;
+  return { ...(data as ActivitySection), id: realSet } as ActivitySection;
 }
 
 /**
@@ -42,7 +42,9 @@ export async function getAllSets(): Promise<ActivitySection[]> {
  * @param {string} pageName Name of the page you want the sets for.
  * @returns {Promise<Set[]>} list of contents of the sets listed in the page yaml
  */
-export async function getPageSets(pageName: string): Promise<ActivitySection[]> {
+export async function getPageSets(
+  pageName: string
+): Promise<ActivitySection[]> {
   const pageData = await getPageByName(pageName);
   const sets = pageData.sets.map((set) => getSetByName(set));
 

--- a/src/pages/[tabId].tsx
+++ b/src/pages/[tabId].tsx
@@ -58,7 +58,7 @@ const TabPage: React.FC<IndexPageProps> = ({ page, allPages, allSets }) => {
         {allSets?.map((p, index) => (
           <Container
             className="pt-4"
-            key={p.sectionTitle + "_" + p.eventList.length + "_" + index}
+            key={p.activityList + "_" + p.activityList.length + "_" + index}
           >
             <Set info={p}></Set>
           </Container>

--- a/src/pages/activities/[page].tsx
+++ b/src/pages/activities/[page].tsx
@@ -7,7 +7,7 @@ import { BackBtn } from "../../common/BackBtn";
 import { Media, CallStatus } from "../../common/Media";
 import { ActivityInfo, ActivityInfoProps } from "../../common/ActivityInfo";
 import { getActivityByName, getAllActivities } from "../../libs/activitiesAPI";
-import { useActiveUser } from "../../common/UserProvider";
+// import { useActiveUser } from "../../common/UserProvider";
 import { Footer } from "../../common/Footer";
 
 // This works but a little janky for now.
@@ -21,16 +21,19 @@ function stripHtmlTags(str: any) {
   return str.replace(/<[^>]*>/g, "").replace(/^\s+|\s+$/g, "");
 }
 
-const ActivityPage: React.FC<ActivityInfoProps> = ({...ActivityInfoProps}) => {
+const ActivityPage: React.FC<ActivityInfoProps> = ({
+  ...ActivityInfoProps
+}) => {
   // add an ellipsis if longer than 100 characters
   const desc = stripHtmlTags(ActivityInfoProps.content);
-  const user = useActiveUser();
+  // const user = useActiveUser();
   const trimDesc = desc.length > 100 ? `${desc.substring(0, 100)}...` : desc;
   const pageURL = `https://tamudatathon.com/events/activities/${ActivityInfoProps.id}`;
 
   let callStatus = CallStatus.NOT_STARTED;
   if (
-    new Date().getTime() >= new Date(ActivityInfoProps.startTime).getTime() - 900000 &&
+    new Date().getTime() >=
+      new Date(ActivityInfoProps.startTime).getTime() - 900000 &&
     new Date().getTime() <= new Date(ActivityInfoProps.endTime).getTime()
   ) {
     callStatus = CallStatus.ONGOING;
@@ -81,7 +84,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
   const pages = await getAllActivities();
 
   return {
-    paths: pages.map(page => ({
+    paths: pages.map((page) => ({
       params: {
         page: page.id,
       },

--- a/src/pages/activities/[page].tsx
+++ b/src/pages/activities/[page].tsx
@@ -5,66 +5,45 @@ import { Head } from "../../common/Head";
 import { Navbar } from "../../common/Navbar";
 import { BackBtn } from "../../common/BackBtn";
 import { Media, CallStatus } from "../../common/Media";
-import { ActivityInfo, SocialInfo } from "../../common/ActivityInfo";
+import { ActivityInfo, ActivityInfoProps } from "../../common/ActivityInfo";
 import { getActivityByName, getAllActivities } from "../../libs/activitiesAPI";
 import { useActiveUser } from "../../common/UserProvider";
 import { Footer } from "../../common/Footer";
-
-interface PageInterface {
-  mediaLink: string;
-  mediaType: "embed_url" | "meeting_url";
-  name: string;
-  content: string;
-  startTime: Date;
-  id: string;
-  endTime: Date;
-  presenter: string;
-  presenterAbout: string;
-  presenterSocials: SocialInfo[];
-  slackChannel?: string;
-  slackChannelLink?: string;
-  relatedActivities: string[];
-  thumbnail: string;
-}
-
-interface ActivityProps {
-  page: PageInterface;
-}
 
 // This works but a little janky for now.
 // https://www.w3resource.com/javascript-exercises/javascript-string-exercise-35.php
 // https://stackoverflow.com/questions/1418050/string-strip-for-javascript
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function stripHtmlTags(str: any) {
-  if (str === null || str === "") return false;
+  if (!str || str === null || str === "") return false;
   else str = str.toString();
   // strip HTML & whitespace
   return str.replace(/<[^>]*>/g, "").replace(/^\s+|\s+$/g, "");
 }
 
-const ActivityPage: React.FC<ActivityProps> = ({ page }: ActivityProps) => {
+const ActivityPage: React.FC<ActivityInfoProps> = ({...ActivityInfoProps}) => {
   // add an ellipsis if longer than 100 characters
-  const desc = stripHtmlTags(page.content);
+  const desc = stripHtmlTags(ActivityInfoProps.content);
   const user = useActiveUser();
   const trimDesc = desc.length > 100 ? `${desc.substring(0, 100)}...` : desc;
-  const pageURL = `https://tamudatathon.com/events/activities/${page.id}`;
+  const pageURL = `https://tamudatathon.com/events/activities/${ActivityInfoProps.id}`;
 
   let callStatus = CallStatus.NOT_STARTED;
   if (
-    new Date().getTime() >= new Date(page.startTime).getTime() - 900000 &&
-    new Date().getTime() <= new Date(page.endTime).getTime()
+    new Date().getTime() >= new Date(ActivityInfoProps.startTime).getTime() - 900000 &&
+    new Date().getTime() <= new Date(ActivityInfoProps.endTime).getTime()
   ) {
     callStatus = CallStatus.ONGOING;
   }
-  if (new Date().getTime() > new Date(page.endTime).getTime()) {
+  if (new Date().getTime() > new Date(ActivityInfoProps.endTime).getTime()) {
     callStatus = CallStatus.FINISHED;
   }
   return (
     <>
-      <Head title={`${page.name} - TAMU Datathon`}>
-        <meta property="og:title" content={page.name} />
+      <Head title={`${ActivityInfoProps.name} - TAMU Datathon`}>
+        <meta property="og:title" content={ActivityInfoProps.name} />
         <meta property="og:description" content={trimDesc} />
-        <meta property="og:image" content={page.thumbnail} />
+        <meta property="og:image" content={ActivityInfoProps.thumbnail} />
         <meta property="og:url" content={pageURL} />
         <meta name="twitter:card" content="summary_large_image" />
       </Head>
@@ -72,27 +51,15 @@ const ActivityPage: React.FC<ActivityProps> = ({ page }: ActivityProps) => {
       <BackBtn url={"/"}></BackBtn>
       <Media
         link={
-          page.mediaType === "meeting_url"
-            ? `/events/api/join.ts?activityId=${page.id}`
-            : page.mediaLink
+          ActivityInfoProps.mediaType === "meeting_url"
+            ? `/events/api/join.ts?activityId=${ActivityInfoProps.id}`
+            : ActivityInfoProps.mediaLink
         }
-        type={page.mediaType}
+        type={ActivityInfoProps.mediaType}
         callStatus={callStatus}
       ></Media>
       <br />
-      <ActivityInfo
-        title={page.name}
-        id={page.id}
-        description={page.content}
-        startTime={new Date(page.startTime)}
-        endTime={new Date(page.endTime)}
-        speakerName={page.presenter}
-        speakerAbout={page.presenterAbout}
-        speakerSocials={page.presenterSocials}
-        relatedActivities={page.relatedActivities}
-        slackChannel={page.slackChannel}
-        slackChannelLink={page.slackChannelLink}
-      ></ActivityInfo>
+      <ActivityInfo {...ActivityInfoProps}></ActivityInfo>
       <Footer />
     </>
   );
@@ -102,10 +69,10 @@ export default ActivityPage;
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
   const activityName = (params ? params.page : "") as string;
-  const page = await getActivityByName(activityName);
+  const activity = await getActivityByName(activityName);
   return {
     props: {
-      page,
+      ...activity,
     },
   };
 };
@@ -114,13 +81,11 @@ export const getStaticPaths: GetStaticPaths = async () => {
   const pages = await getAllActivities();
 
   return {
-    paths: pages.map((pages) => {
-      return {
-        params: {
-          page: pages.id,
-        },
-      };
-    }),
+    paths: pages.map(page => ({
+      params: {
+        page: page.id,
+      },
+    })),
     fallback: false,
   };
 };

--- a/src/pages/sets/[page].tsx
+++ b/src/pages/sets/[page].tsx
@@ -28,7 +28,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 export const getStaticPaths: GetStaticPaths = async () => {
   const sets = await getAllSets();
   return {
-    paths: sets.map(set => ({
+    paths: sets.map((set) => ({
       params: {
         page: set.id,
       },

--- a/src/pages/sets/[page].tsx
+++ b/src/pages/sets/[page].tsx
@@ -28,13 +28,11 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 export const getStaticPaths: GetStaticPaths = async () => {
   const sets = await getAllSets();
   return {
-    paths: sets.map((sets) => {
-      return {
-        params: {
-          page: sets.id,
-        },
-      };
-    }),
+    paths: sets.map(set => ({
+      params: {
+        page: set.id,
+      },
+    })),
     fallback: false,
   };
 };


### PR DESCRIPTION
- update example activity .md file to include duration (TODO: remove end time)
- make `ActivityInfo` interface single source of truth (SST) for reading activity file & component props
- update interface in `Card/interfaces` to use SST from `ActivityInfo`
- update interface in `Set/interfaces` to be SST for reading set files & populating props
- removed ids from all markdown files, and example files
- update time in opening_ceremony